### PR TITLE
[SendGrid] Fix recipient getting sent as reply-to address

### DIFF
--- a/Sources/MailCore/Extensions/Message+SendGrid.swift
+++ b/Sources/MailCore/Extensions/Message+SendGrid.swift
@@ -28,7 +28,13 @@ extension Mailer.Message {
                 ]
             )
         }
-        let message = SendGridEmail(from: EmailAddress(email: from), replyTo: EmailAddress(email: to), subject: subject, content: content)
+
+        let message = SendGridEmail(
+            personalizations: [Personalization(to: [EmailAddress(email: to)])],
+            from: EmailAddress(email: from),
+            subject: subject,
+            content: content)
+
         return message
     }
     


### PR DESCRIPTION
As reported on Discord, trying to send an email via SendGrid throws the following error:

```
failure(SendGrid.SendGridError(errors: Optional([SendGrid.SendGridErrorResponse(message: Optional("The personalizations field is required and must have at least one personalization."), field: Optional("personalizations"), help: Optional("http://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/errors.html#-Personalizations-Errors"))])))
```

This PR fixes the issue by sending the recipient email address in the correct place.