### PR TITLE
Send attachments with SMTP

### DIFF
--- a/Sources/MailCore/Extensions/Message+SMTP.swift
+++ b/Sources/MailCore/Extensions/Message+SMTP.swift
@@ -20,15 +20,12 @@ extension Mailer.Message {
         let ccUsers = (cc ?? []).map({ Mail.User(email: $0) })
         let bccUsers = (bcc ?? []).map({ Mail.User(email: $0) })
         
-        let attachments: [Attachment]
+        var attachments: [Attachment] = self.attachments ?? []
         if let html = html {
-            attachments = [Attachment(htmlContent: html)]
-        } else {
-            attachments = []
+            attachments.append(Attachment(htmlContent: html))
         }
         
         let mail = Mail(from: fromUser, to: [toUser], cc: ccUsers, bcc: bccUsers, subject: subject, text: text, attachments: attachments)
         return mail
     }
-    
 }

--- a/Sources/MailCore/MailCore.swift
+++ b/Sources/MailCore/MailCore.swift
@@ -31,9 +31,10 @@ public class Mailer: MailerService {
         public let subject: String
         public let text: String
         public let html: String?
+        public let attachments: [Attachment]?
         
         /// Message init
-        public init(from: String, to: String, cc: [String]? = nil, bcc: [String]? = nil, subject: String, text: String, html: String? = nil) {
+        public init(from: String, to: String, cc: [String]? = nil, bcc: [String]? = nil, subject: String, text: String, html: String? = nil, attachments: [Attachment]? = nil) {
             self.from = from
             self.to = to
             self.cc = cc
@@ -41,6 +42,7 @@ public class Mailer: MailerService {
             self.subject = subject
             self.text = text
             self.html = html
+            self.attachments = attachments
         }
     }
     


### PR DESCRIPTION
Example usage with a pdf file from the `Public` folder:

    let directory = DirectoryConfig.detect()
    let configDir = "Public/storage/pdf"
    let pdfData = try Data(contentsOf: URL(fileURLWithPath: directory.workDir)
        .appendingPathComponent(configDir, isDirectory: true)
        .appendingPathComponent(some.pdf, isDirectory: false))
    
    let attachments: [Attachment] = [
        Attachment(data: pdfData, mime: "application/pdf", name: "some.pdf", inline: false)
    ]
    return try req.view().render("my-template").map { (view) -> [Mailer.Message] in
        return users.map { user in
            return Mailer.Message(
                from: "from@example.com",
                to: "to@example.com",
                subject: "Example subject", text: "Example subject",
                html: String(data: view.data, encoding: .utf8) ?? "",
                attachments: attachments
            )
        }
    }

Again, additions only, shouldn't break anything.